### PR TITLE
Use source-map to remove eval in output

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@dolbyio/webrtc-stats",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@dolbyio/webrtc-stats",
-            "version": "1.0.1",
+            "version": "1.0.2",
             "license": "MIT",
             "dependencies": {
                 "js-logger": "^1.6.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@dolbyio/webrtc-stats",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "description": "Dolby.io WebRTC Statistics",
     "main": "dist/webrtc-stats.js",
     "typings": "dist/index.d.ts",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -14,7 +14,7 @@ module.exports = {
     resolve: {
         extensions: ['.tsx', '.ts', '.js'],
     },
-    devtool: 'eval-source-map',
+    devtool: 'source-map',
     output: {
         filename: 'webrtc-stats.js',
         sourceMapFilename: 'webrtc-stats.js.map',


### PR DESCRIPTION
Use `source-map` instead of `eval-source-map` to remove the use of `eval` in the output distribution file.