### PR TITLE
Fix issue with calculatePacketsLostRatio #15

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -30,7 +30,7 @@ export const calculatePacketsLostRatio = (
         return 0;
     }
 
-    const currentLostPackages = totalPacketsLost - (lastTotalPacketsLost ?? 0);
-    const currentReceivedPackages = totalPacketsReceived - (lastTotalPacketsReceived ?? 0);
-    return currentLostPackages / currentReceivedPackages;
+    const currentLostPackets = totalPacketsLost - (lastTotalPacketsLost ?? 0);
+    const currentReceivedPackets = totalPacketsReceived - (lastTotalPacketsReceived ?? 0);
+    return currentLostPackets / currentReceivedPackets;
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -26,11 +26,13 @@ export const calculatePacketsLostRatio = (
     lastTotalPacketsLost?: number,
     lastTotalPacketsReceived?: number
 ): number => {
-    if (totalPacketsReceived == 0) {
+    const currentLostPackets = totalPacketsLost - (lastTotalPacketsLost ?? 0);
+    const currentReceivedPackets = totalPacketsReceived - (lastTotalPacketsReceived ?? 0);
+    const currentPacketsExpected = currentLostPackets + currentReceivedPackets;
+
+    if (currentPacketsExpected === 0) {
         return 0;
     }
 
-    const currentLostPackets = totalPacketsLost - (lastTotalPacketsLost ?? 0);
-    const currentReceivedPackets = totalPacketsReceived - (lastTotalPacketsReceived ?? 0);
-    return currentLostPackets / currentReceivedPackets;
+    return currentLostPackets / currentPacketsExpected;
 };

--- a/src/webRTCStats.ts
+++ b/src/webRTCStats.ts
@@ -247,7 +247,7 @@ export class WebRTCStats extends EventEmitter implements WebRTCStats {
     async #getInputAudio(rtcStatsReport: RTCStatsReport, entry: RTCInboundRtpStreamStats, last: InputAudio): Promise<InputAudio> {
         const bitrate = calculateRate(entry.timestamp, entry.bytesReceived, last?.timestamp, last?.totalBytesReceived);
         const packetRate = calculateRate(entry.timestamp, entry.packetsReceived, last?.timestamp, last?.totalPacketsReceived);
-        const packetLossRatio = calculatePacketsLostRatio(entry.packetsLost, entry.packetsReceived, last?.totalPacketsReceived, last?.totalPacketsLost);
+        const packetLossRatio = calculatePacketsLostRatio(entry.packetsLost, entry.packetsReceived, last?.totalPacketsLost, last?.totalPacketsReceived);
         const packetLossDelta = (entry.packetsLost ?? 0) - (last?.totalPacketsLost ?? 0);
         const codec = this.#getCodec(rtcStatsReport, entry.codecId);
 

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -58,9 +58,16 @@ describe('utils test suite', () => {
     });
 
     test('calculatePacketsLostRatio', () => {
-        expect(calculatePacketsLostRatio(100, 0)).toEqual(0);
-        expect(calculatePacketsLostRatio(100, 200)).toEqual(0.5);
-        expect(calculatePacketsLostRatio(100, 200, 50)).toEqual(0.25);
-        expect(calculatePacketsLostRatio(100, 200, 50, 100)).toEqual(0.5);
+        expect(calculatePacketsLostRatio(100, 0)).toEqual(1);
+        expect(calculatePacketsLostRatio(0, 1)).toEqual(0);
+
+        expect(calculatePacketsLostRatio(100, 300)).toEqual(0.25);
+        expect(calculatePacketsLostRatio(150, 100, 50)).toEqual(0.5);
+        expect(calculatePacketsLostRatio(150, 200, 50, 100)).toEqual(0.5);
+
+        // corner cases
+        expect(calculatePacketsLostRatio(0, 0, 0, 0)).toEqual(0);
+        expect(calculatePacketsLostRatio(100, 100, 100, 100)).toEqual(0);
+        expect(calculatePacketsLostRatio(0, 0)).toEqual(0);
     });
 });


### PR DESCRIPTION
 - Fix the arguments (`last?.totalPacketsLost`, `last?.totalPacketsReceived`) order for `calculatePacketsLostRatio` call
 - Fix the formula for packet loss ratio calculation